### PR TITLE
FEAT: introducing new overload for post method

### DIFF
--- a/src/Mattioli.Configurations/Http/BaseHttpClient.cs
+++ b/src/Mattioli.Configurations/Http/BaseHttpClient.cs
@@ -81,6 +81,21 @@ namespace Mattioli.Configurations.Http
             return result!;
         }
 
+        protected async Task PostAsync<TRequest>(
+            string path,
+            TRequest request,
+            CancellationToken cancellationToken)
+            where TRequest : class
+        {
+            var url = _httpClient!.BaseAddress!.ToString().AppendPathSegment(path);
+
+            string json = JsonConvert.SerializeObject(request);
+
+            StringContent bodyContent = new(json, Encoding.UTF8, "application/json");
+
+            await _httpClient.PostAsync(url, bodyContent, cancellationToken);
+        }
+
         private static IEnumerable<string> BuildFilters<T>(T queryFilters) where T : class
         {
             if (queryFilters == null)

--- a/src/Mattioli.Configurations/Http/BaseHttpClient.cs
+++ b/src/Mattioli.Configurations/Http/BaseHttpClient.cs
@@ -66,7 +66,6 @@ namespace Mattioli.Configurations.Http
             string path,
             TRequest request,
             CancellationToken cancellationToken)
-            where TResponse : class
             where TRequest : class
         {
             var url = _httpClient!.BaseAddress!.ToString().AppendPathSegment(path);
@@ -79,21 +78,6 @@ namespace Mattioli.Configurations.Http
 
             var result = JsonConvert.DeserializeObject<TResponse>(await response.Content.ReadAsStringAsync(cancellationToken));
             return result!;
-        }
-
-        protected async Task PostAsync<TRequest>(
-            string path,
-            TRequest request,
-            CancellationToken cancellationToken)
-            where TRequest : class
-        {
-            var url = _httpClient!.BaseAddress!.ToString().AppendPathSegment(path);
-
-            string json = JsonConvert.SerializeObject(request);
-
-            StringContent bodyContent = new(json, Encoding.UTF8, "application/json");
-
-            await _httpClient.PostAsync(url, bodyContent, cancellationToken);
         }
 
         private static IEnumerable<string> BuildFilters<T>(T queryFilters) where T : class


### PR DESCRIPTION
Novo overload criado para o método post que aceita somente o tipo da request sem o tipo do response `PostAsync<TRequest>`

Foi necessário pois só havia o método com `PostAsync<TRequest, TResponse>` e o parâmetro  `TResponse` só aceita tipo referência. A response do Feijuca na criação de Groups é um `bool` tipo valor. Então foi avaliado, criar um overload que não espera uma Response.

```bash
O tipo "bool" deve ser um tipo de referência para que seja usado como parâmetro "TResponse" no tipo ou método genérico "BaseHttpClient.PostAsync<TRequest, TResponse>(string, TRequest, CancellationToken)"
```
<img width="979" height="236" alt="image" src="https://github.com/user-attachments/assets/7d66aa02-a7b6-4ced-b965-5bd9b0cc2b6f" />
